### PR TITLE
refactor: remove goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python3 setup.py install
 Installing this plugin adds support for the Polygon ZkEVM ecosystem:
 
 ```
-ape console --network polygon-zkevm:goerli 
+ape console --network polygon-zkevm:cardona
 ```
 
 ## Development

--- a/ape_polygon_zkevm/ecosystem.py
+++ b/ape_polygon_zkevm/ecosystem.py
@@ -10,13 +10,13 @@ from ape_ethereum.ecosystem import (
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (1101, 1101),
-    "goerli": (1442, 1442),
+    "cardona": (2442, 2442),
 }
 
 
 class PolygonZkEVMConfig(BaseEthereumConfig):
     mainnet: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
-    goerli: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
+    cardona: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
 
 
 class PolygonZkEVM(Ethereum):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ EXPECTED_OUTPUT = """
 polygon-zkevm
 ├── mainnet
 │   └── geth  (default)
-├── goerli
+├── cardona
 │   └── geth  (default)
 └── local  (default)
     └── test  (default)
@@ -47,7 +47,7 @@ def assert_rich_text(actual: str, expected: str):
 def test_networks(runner, cli, polygon_zkevm):
     # Do this in case local env changed it.
     polygon_zkevm.mainnet.set_default_provider("geth")
-    polygon_zkevm.goerli.set_default_provider("geth")
+    polygon_zkevm.cardona.set_default_provider("geth")
 
     result = runner.invoke(cli, ["networks", "list"])
     assert_rich_text(result.output, EXPECTED_OUTPUT)


### PR DESCRIPTION
### What I did
https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

https://polygon.technology/blog/polygon-pos-and-polygon-zkevm-new-testnets-for-polygon-protocols

Polygon zkEVM: Cardona
Network Name: Polygon zkEVM Cardona Testnet
Bridge UI: https://bridge-ui.cardona.zkevm-rpc.com/
New RPC URL: https://rpc.cardona.zkevm-rpc.com/
Chain ID: 2442
Currency symbol: ETH
Block Explorer: https://cardona-zkevm.polygonscan.com/

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
